### PR TITLE
fix: can't switch input methods through the systray menu

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+fcitx5-qt (5.1.3-1deepin1) unstable; urgency=medium
+
+  * fix: can't switch input methods through the systray menu
+
+ -- zsien <quezhiyong@deepin.org>  Fri, 15 Mar 2024 09:55:08 +0800
+
 fcitx5-qt (5.1.3-1) unstable; urgency=medium
 
   * New upstream release.

--- a/debian/patches/0001-Fix-can-t-switch-input-methods-through-the-systray-m.patch
+++ b/debian/patches/0001-Fix-can-t-switch-input-methods-through-the-systray-m.patch
@@ -1,0 +1,33 @@
+From: zsien <quezhiyong@deepin.org>
+Date: Fri, 15 Mar 2024 09:53:26 +0800
+Subject: Fix can't switch input methods through the systray menu
+
+Call focusIn only when input method is accepted,
+so that focusIn will not be called when the
+systray menu pops up.
+---
+ qt5/platforminputcontext/qfcitxplatforminputcontext.cpp | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/qt5/platforminputcontext/qfcitxplatforminputcontext.cpp b/qt5/platforminputcontext/qfcitxplatforminputcontext.cpp
+index f89ca7f..93c0de8 100644
+--- a/qt5/platforminputcontext/qfcitxplatforminputcontext.cpp
++++ b/qt5/platforminputcontext/qfcitxplatforminputcontext.cpp
+@@ -523,7 +523,7 @@ void QFcitxPlatformInputContext::setFocusObject(QObject *object) {
+         return;
+     }
+ 
+-    if (proxy) {
++    if (proxy && !shouldDisableInputMethod()) {
+         proxy->focusIn();
+         // We need to delegate this otherwise it may cause self-recursion in
+         // certain application like libreoffice.
+@@ -611,7 +611,7 @@ void QFcitxPlatformInputContext::createInputContextFinished(
+     if (proxy->isValid() && !uuid.isEmpty()) {
+         QWindow *window = focusWindowWrapper();
+         setFocusGroupForX11(uuid);
+-        if (window && window == w) {
++        if (window && window == w && !shouldDisableInputMethod()) {
+             cursorRectChanged();
+             proxy->focusIn();
+         }

--- a/debian/patches/0002-Compatible-with-QPlatformInputContextFactory-request.patch
+++ b/debian/patches/0002-Compatible-with-QPlatformInputContextFactory-request.patch
@@ -1,0 +1,22 @@
+From: zsien <quezhiyong@deepin.org>
+Date: Tue, 16 Apr 2024 11:18:33 +0800
+Subject: Compatible with QPlatformInputContextFactory::requested() returning
+ QStringList
+
+---
+ qt6/immodule-probing/main.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/qt6/immodule-probing/main.cpp b/qt6/immodule-probing/main.cpp
+index be5bec1..71e05e4 100644
+--- a/qt6/immodule-probing/main.cpp
++++ b/qt6/immodule-probing/main.cpp
+@@ -16,7 +16,7 @@ int main(int argc, char *argv[]) {
+     std::cout << "QT_QPA_PLATFORM=" << app.platformName().toStdString()
+               << std::endl;
+     std::cout << "QT_IM_MODULE="
+-              << QPlatformInputContextFactory::requested().toStdString()
++              << QPlatformInputContextFactory::requested().join(";").toStdString()
+               << std::endl;
+     auto inputContext =
+         QGuiApplicationPrivate::platformIntegration()->inputContext();

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,0 +1,1 @@
+0001-Fix-can-t-switch-input-methods-through-the-systray-m.patch

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,1 +1,2 @@
 0001-Fix-can-t-switch-input-methods-through-the-systray-m.patch
+0002-Compatible-with-QPlatformInputContextFactory-request.patch


### PR DESCRIPTION
Call focusIn only when input method is accepted,
so that focusIn will not be called when the
systray menu pops up.

linuxdeepin/developer-center#7327