### PR TITLE
fix: Handle QLineEdit focus object correctly with QCompleter in Qt6

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+fcitx5-qt (5.1.8-2deepin3) unstable; urgency=medium
+
+  * Handle QLineEdit focus object correctly with QCompleter in Qt6.
+
+ -- Wang Yu <wangyu@uniontch.com>  Wed, 18 Jun 2025 10:27:53 +0800
+
 fcitx5-qt (5.1.8-2deepin2) unstable; urgency=medium
 
   * update version for rebuild.

--- a/debian/patches/0002-Handle-QLineEdit-focus-object-correctly-with-QCompleter.patch
+++ b/debian/patches/0002-Handle-QLineEdit-focus-object-correctly-with-QCompleter.patch
@@ -1,0 +1,14 @@
+Index: fcitx5-qt-community/qt5/platforminputcontext/qfcitxplatforminputcontext.cpp
+===================================================================
+--- fcitx5-qt-community.orig/qt5/platforminputcontext/qfcitxplatforminputcontext.cpp
++++ fcitx5-qt-community/qt5/platforminputcontext/qfcitxplatforminputcontext.cpp
+@@ -1249,9 +1249,6 @@ QWindow *QFcitxPlatformInputContext::foc
+             break;
+         }
+         QObject *realFocusObject = focusObjectWrapper();
+-        if (qGuiApp->focusObject() == realFocusObject) {
+-            break;
+-        }
+         auto *widget = qobject_cast<QWidget *>(realFocusObject);
+         if (!widget) {
+             break;

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,1 +1,2 @@
 0001-Fix-can-t-switch-input-methods-through-the-systray-m.patch
+0002-Handle-QLineEdit-focus-object-correctly-with-QCompleter.patch


### PR DESCRIPTION
In Qt6, when using QLineEdit with QCompleter during Chinese input:
- qGuiApp->focusObject() and realFocusObject are both QLineEdit
- This is logically correct as the focus is indeed on QLineEdit
- However, it caused filterEvent to return false and trigger unwanted keypress events
- Remove redundant check to ensure proper input method handling

Log: Handle QLineEdit focus object correctly with QCompleter in Qt6
Upstream: https://github.com/fcitx/fcitx5-qt/pull/71