### PR TITLE
feat: add patches from master branch for 5.1.9-1deepin1

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+fcitx5-qt (5.1.9-1deepin1) unstable; urgency=medium
+
+  * Add patches from master branch:
+    - 0001-Fix-can-t-switch-input-methods-through-the-systray-m.patch
+    - 0002-Handle-QLineEdit-focus-object-correctly-with-QCompleter.patch
+
+ -- Wang Yu <wangyu@uniontech.com>  Wed, 12 Mar 2025 10:50:00 +0800
+
 fcitx5-qt (5.1.9-1) unstable; urgency=medium
 
   * New upstream release.

--- a/debian/patches/0001-Fix-can-t-switch-input-methods-through-the-systray-m.patch
+++ b/debian/patches/0001-Fix-can-t-switch-input-methods-through-the-systray-m.patch
@@ -1,0 +1,33 @@
+From: zsien <quezhiyong@deepin.org>
+Date: Fri, 15 Mar 2024 09:53:26 +0800
+Subject: Fix can't switch input methods through the systray menu
+
+Call focusIn only when input method is accepted,
+so that focusIn will not be called when the
+systray menu pops up.
+---
+ qt5/platforminputcontext/qfcitxplatforminputcontext.cpp | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/qt5/platforminputcontext/qfcitxplatforminputcontext.cpp b/qt5/platforminputcontext/qfcitxplatforminputcontext.cpp
+index b59c13a..caf44e7 100644
+--- a/qt5/platforminputcontext/qfcitxplatforminputcontext.cpp
++++ b/qt5/platforminputcontext/qfcitxplatforminputcontext.cpp
+@@ -541,7 +541,7 @@ void QFcitxPlatformInputContext::setFocusObject(QObject *object) {
+         return;
+     }
+ 
+-    if (proxy) {
++    if (proxy && !shouldDisableInputMethod()) {
+         proxy->focusIn();
+         // We need to delegate this otherwise it may cause self-recursion in
+         // certain application like libreoffice.
+@@ -634,7 +634,7 @@ void QFcitxPlatformInputContext::createInputContextFinished(
+ #else
+         Q_UNUSED(uuid);
+ #endif
+-        if (window && window == w) {
++        if (window && window == w && !shouldDisableInputMethod()) {
+             cursorRectChanged();
+             proxy->focusIn();
+         }

--- a/debian/patches/0002-Handle-QLineEdit-focus-object-correctly-with-QCompleter.patch
+++ b/debian/patches/0002-Handle-QLineEdit-focus-object-correctly-with-QCompleter.patch
@@ -1,0 +1,14 @@
+Index: fcitx5-qt-community/qt5/platforminputcontext/qfcitxplatforminputcontext.cpp
+===================================================================
+--- fcitx5-qt-community.orig/qt5/platforminputcontext/qfcitxplatforminputcontext.cpp
++++ fcitx5-qt-community/qt5/platforminputcontext/qfcitxplatforminputcontext.cpp
+@@ -1249,9 +1249,6 @@ QWindow *QFcitxPlatformInputContext::foc
+             break;
+         }
+         QObject *realFocusObject = focusObjectWrapper();
+-        if (qGuiApp->focusObject() == realFocusObject) {
+-            break;
+-        }
+         auto *widget = qobject_cast<QWidget *>(realFocusObject);
+         if (!widget) {
+             break;

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,0 +1,2 @@
+0001-Fix-can-t-switch-input-methods-through-the-systray-m.patch
+0002-Handle-QLineEdit-focus-object-correctly-with-QCompleter.patch


### PR DESCRIPTION
Add two patches to fix input method issues:
- Fix systray menu input method switching
- Handle QLineEdit focus with QCompleter

从 master 分支移植两个 patch，修复托盘菜单切换输入法和 QLineEdit 焦点问题。

Log: 移植 master 分支的 patch 到 topic
Influence: 修复托盘菜单无法切换输入法和 QLineEdit 配合 QCompleter 的焦点问题。