### PR TITLE
fix: retry virtual keyboard show after focus settles

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+fcitx5-qt (5.1.9-1deepin2) unstable; urgency=medium
+
+  * Add patch to retry virtual keyboard show after focus settles:
+    - 0003-retry-virtual-keyboard-show-after-focus-settles.patch
+
+ -- Wang Yu <wangyu@uniontech.com>  Wed, 08 Jul 2026 15:54:08 +0800
+
 fcitx5-qt (5.1.9-1deepin1) unstable; urgency=medium
 
   * Add patches from master branch:

--- a/debian/patches/0002-Handle-QLineEdit-focus-object-correctly-with-QCompleter.patch
+++ b/debian/patches/0002-Handle-QLineEdit-focus-object-correctly-with-QCompleter.patch
@@ -1,7 +1,6 @@
-Index: fcitx5-qt-community/qt5/platforminputcontext/qfcitxplatforminputcontext.cpp
-===================================================================
---- fcitx5-qt-community.orig/qt5/platforminputcontext/qfcitxplatforminputcontext.cpp
-+++ fcitx5-qt-community/qt5/platforminputcontext/qfcitxplatforminputcontext.cpp
+diff --git a/qt5/platforminputcontext/qfcitxplatforminputcontext.cpp b/qt5/platforminputcontext/qfcitxplatforminputcontext.cpp
+--- a/qt5/platforminputcontext/qfcitxplatforminputcontext.cpp
++++ b/qt5/platforminputcontext/qfcitxplatforminputcontext.cpp
 @@ -1249,9 +1249,6 @@ QWindow *QFcitxPlatformInputContext::foc
              break;
          }

--- a/debian/patches/0003-retry-virtual-keyboard-show-after-focus-settles.patch
+++ b/debian/patches/0003-retry-virtual-keyboard-show-after-focus-settles.patch
@@ -1,0 +1,30 @@
+diff --git a/qt5/platforminputcontext/qfcitxplatforminputcontext.cpp b/qt5/platforminputcontext/qfcitxplatforminputcontext.cpp
+--- a/qt5/platforminputcontext/qfcitxplatforminputcontext.cpp
++++ b/qt5/platforminputcontext/qfcitxplatforminputcontext.cpp
+@@ -887,7 +887,26 @@ void QFcitxPlatformInputContext::showInp
+     if (proxy == nullptr) {
+         return;
+     }
++
+     proxy->showVirtualKeyboard();
++
++    // First click may race with async focus/cursor updates; retry once after
++    // they settle, since a failed show may not emit
++    // VirtualKeyboardVisibilityChanged(false) to drive an event-based retry.
++    auto window = QPointer<QWindow>(lastWindow_);
++    QTimer::singleShot(100, this, [this, window]() {
++        if ((window && window != lastWindow_) || !objectAcceptsInputMethod()) {
++            return;
++        }
++
++        auto *proxy = validIC();
++        if (proxy == nullptr || proxy->isVirtualKeyboardVisible()) {
++            updateInputPanelVisible();
++            return;
++        }
++
++        proxy->showVirtualKeyboard();
++    });
+ }
+ 
+ void QFcitxPlatformInputContext::hideInputPanel() {

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,2 +1,3 @@
 0001-Fix-can-t-switch-input-methods-through-the-systray-m.patch
 0002-Handle-QLineEdit-focus-object-correctly-with-QCompleter.patch
+0003-retry-virtual-keyboard-show-after-focus-settles.patch


### PR DESCRIPTION
Add patch 0003 to retry showVirtualKeyboard() once after focus/cursor updates reach fcitx, fixing keyboard not showing on first click into QLineEdit-style widgets.

新增补丁0003，在焦点和光标信息到达fcitx后重试一次showVirtualKeyboard，
修复首次点击QLineEdit等控件时虚拟键盘不显示的问题。

Log: 修复首次点击控件时虚拟键盘不显示的问题
Influence: 修复后首次点击QLineEdit等控件时虚拟键盘能正常显示，提升输入体验。